### PR TITLE
update to new multiformats

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto'
+import randomBytes from 'randombytes'
 import aes from 'js-crypto-aes'
 import { CID } from 'multiformats'
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "(Apache-2.0 AND MIT)",
   "dependencies": {
     "js-crypto-aes": "^1.0.0",
+    "randombytes": "^2.1.0",
     "multiformats": "^11.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "(Apache-2.0 AND MIT)",
   "dependencies": {
     "js-crypto-aes": "^1.0.0",
-    "multiformats": "^4.4.3"
+    "multiformats": "^11.0.1"
   },
   "devDependencies": {
     "hundreds": "0.0.9",

--- a/test/test-basics.js
+++ b/test/test-basics.js
@@ -1,13 +1,12 @@
 /* globals describe, it */
-import { encode, decode, crypto, name, code } from '../index.js'
+import { encode, decode, code, name, encrypt, decrypt, crypto } from '../index.js'
 import { sha256 as hasher } from 'multiformats/hashes/sha2'
-import raw from 'multiformats/codecs/raw'
-import { codec } from 'multiformats/codecs/codec'
+import * as raw from 'multiformats/codecs/raw'
 import { randomBytes } from 'crypto'
 import * as Block from 'multiformats/block'
 import { deepStrictEqual as same } from 'assert'
 
-const eb = codec({ encode, decode, name, code })
+const eb = { encode, decode, code, name, encrypt, decrypt, crypto }
 
 describe('encrypted-block', () => {
   it('encrypt/decrypt raw block', async () => {


### PR DESCRIPTION
my environment doens't fully like some of these tests, but this seems to be mostly passing. 

only error here is:

```
± npm test           

> encrypted-block@0.0.0-dev test
> npm run lint && npm run test:node && npm run test:cjs


> encrypted-block@0.0.0-dev lint
> standard


> encrypted-block@0.0.0-dev test:node
> hundreds mocha test/test-*.js



  encrypted-block
    ✓ encrypt/decrypt raw block


  1 passing (5ms)

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 index.js |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------

> encrypted-block@0.0.0-dev test:cjs
> npm run build && mocha dist/cjs/node-test/test-*.js


> encrypted-block@0.0.0-dev build
> npm_config_yes=true npx ipjs@latest build --tests

parsing file:///Users/jchris/Documents/GitHub/encrypted-block/index.js
parsed file:///Users/jchris/Documents/GitHub/encrypted-block/index.js
parsing file:///Users/jchris/Documents/GitHub/encrypted-block/test/test-basics.js
parsed file:///Users/jchris/Documents/GitHub/encrypted-block/test/test-basics.js
'multiformats/hashes/sha2' is imported by dist/esm/browser-test/test-basics.js, but could not be resolved – treating it as an external dependency
'multiformats/codecs/raw' is imported by dist/esm/browser-test/test-basics.js, but could not be resolved – treating it as an external dependency
'crypto' is imported by dist/esm/browser-test/test-basics.js, but could not be resolved – treating it as an external dependency
'multiformats/block' is imported by dist/esm/browser-test/test-basics.js, but could not be resolved – treating it as an external dependency
'assert' is imported by dist/esm/browser-test/test-basics.js, but could not be resolved – treating it as an external dependency
'crypto' is imported by dist/esm/index.js, but could not be resolved – treating it as an external dependency
'js-crypto-aes' is imported by dist/esm/index.js, but could not be resolved – treating it as an external dependency
'multiformats' is imported by dist/esm/index.js, but could not be resolved – treating it as an external dependency
'multiformats/hashes/sha2' is imported by dist/esm/node-test/test-basics.js, but could not be resolved – treating it as an external dependency
'multiformats/codecs/raw' is imported by dist/esm/node-test/test-basics.js, but could not be resolved – treating it as an external dependency
'crypto' is imported by dist/esm/node-test/test-basics.js, but could not be resolved – treating it as an external dependency
'multiformats/block' is imported by dist/esm/node-test/test-basics.js, but could not be resolved – treating it as an external dependency
'assert' is imported by dist/esm/node-test/test-basics.js, but could not be resolved – treating it as an external dependency

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /Users/jchris/Documents/GitHub/encrypted-block/node_modules/multiformats/package.json
    at new NodeError (node:internal/errors:393:5)
    at throwExportsNotFound (node:internal/modules/esm/resolve:340:9)
    at packageExportsResolve (node:internal/modules/esm/resolve:564:7)
    at resolveExports (node:internal/modules/cjs/loader:492:36)
    at Module._findPath (node:internal/modules/cjs/loader:532:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:941:27)
    at Module._load (node:internal/modules/cjs/loader:803:27)
    at Module.require (node:internal/modules/cjs/loader:1021:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/Users/jchris/Documents/GitHub/encrypted-block/dist/cjs/index.js:7:20)
    at Module._compile (node:internal/modules/cjs/loader:1119:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Module._load (node:internal/modules/cjs/loader:838:12)
    at Module.require (node:internal/modules/cjs/loader:1021:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/Users/jchris/Documents/GitHub/encrypted-block/dist/cjs/node-test/test-basics.js:3:13)
    at Module._compile (node:internal/modules/cjs/loader:1119:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1173:10)
    at Module.load (node:internal/modules/cjs/loader:997:32)
    at Module._load (node:internal/modules/cjs/loader:838:12)
    at Module.require (node:internal/modules/cjs/loader:1021:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at exports.requireOrImport (/Users/jchris/Documents/GitHub/encrypted-block/node_modules/mocha/lib/esm-utils.js:42:12)
    at exports.loadFilesAsync (/Users/jchris/Documents/GitHub/encrypted-block/node_modules/mocha/lib/esm-utils.js:55:34)
    at Mocha.loadFilesAsync (/Users/jchris/Documents/GitHub/encrypted-block/node_modules/mocha/lib/mocha.js:473:19)
    at singleRun (/Users/jchris/Documents/GitHub/encrypted-block/node_modules/mocha/lib/cli/run-helpers.js:125:15)
    at exports.runMocha (/Users/jchris/Documents/GitHub/encrypted-block/node_modules/mocha/lib/cli/run-helpers.js:190:10)
    at exports.handler (/Users/jchris/Documents/GitHub/encrypted-block/node_modules/mocha/lib/cli/run.js:362:11)
    at /Users/jchris/Documents/GitHub/encrypted-block/node_modules/yargs/build/index.cjs:443:71
```